### PR TITLE
Fix issues in closing etp session and websocket

### DIFF
--- a/src/DevKit/Common/EtpSession.cs
+++ b/src/DevKit/Common/EtpSession.cs
@@ -1101,7 +1101,10 @@ namespace Energistics.Etp.Common
                     Logger.Verbose($"[{SessionKey}] Acquiring send lock was canceled in CloseWebSocketAsync");
                     return;
                 }
-
+                catch (ObjectDisposedException)
+                {
+                    Logger.Verbose($"[{SessionKey}] Sendlock was already disopsed. No need to acquire and stop acquiring.");
+                }
                 Logger.Trace($"[{SessionKey}] Closing WebSocket: {reason}");
 
                 _sendTokenSource.Cancel();

--- a/src/DevKit/Native/EtpSessionNativeBase.cs
+++ b/src/DevKit/Native/EtpSessionNativeBase.cs
@@ -297,7 +297,7 @@ namespace Energistics.Etp.Native
                     Logger.Verbose($"[{SessionKey}] Waiting for receive loop to stop.");
 
                     if (_receiveLoopTask != null)
-                        AsyncContext.Run(() => _receiveLoopTask);
+                        AsyncContext.Run(() => _receiveLoopTask.ConfigureAwait(false));
                 }
                 catch (OperationCanceledException)
                 {


### PR DESCRIPTION
This PR attempts to fix the issues related to closing ETP session. #8 
Changes: 
1. Avoid the deadlock when disposing EtpSessionNativeBase
2. Handle ObjectDisposedException when closing websocket connection.