### PR TITLE
Fix the SimpleStreamer field.

### DIFF
--- a/src/DevKit/Common/EtpCapabilities.cs
+++ b/src/DevKit/Common/EtpCapabilities.cs
@@ -32,7 +32,7 @@ namespace Energistics.Etp.Common
         /// <summary>
         /// The underlying dictionary holding the capabilities.
         /// </summary>
-        private IDataValueDictionary Dictionary { get; }
+        protected IDataValueDictionary Dictionary { get; }
 
         /// <summary>
         /// Initializes a new <see cref="EtpCapabilities"/> instance.

--- a/src/DevKit/v11/Protocol/ChannelStreaming/CapabilitiesProducer.cs
+++ b/src/DevKit/v11/Protocol/ChannelStreaming/CapabilitiesProducer.cs
@@ -26,6 +26,10 @@ namespace Energistics.Etp.v11.Protocol.ChannelStreaming
         /// <summary>
         /// Indicates the producer does not accept requests to stream individual channels but always sends all of its channels.
         /// </summary>
-        public bool? SimpleStreamer { get; set; }
+        public bool? SimpleStreamer
+        {
+            get { return TryGetValue<bool>("SimpleStreamer"); }
+            set { Dictionary.SetValue<bool>("SimpleStreamer", value); }
+        }
     }
 }


### PR DESCRIPTION
Fix the SimpleStreamer field to be backed by the dictionary in EtpCapabilities. Otherwise this field is never serialized nor deserialized.